### PR TITLE
remove unnecessary call to unlink after container delete

### DIFF
--- a/oiopy/object_storage.py
+++ b/oiopy/object_storage.py
@@ -222,8 +222,6 @@ class ObjectStorageAPI(API):
         except exc.Conflict as e:
             raise exc.ContainerNotEmpty(e)
 
-        self.directory.unlink(account, container, "meta2", headers=headers)
-
     def container_list(self, account, limit=None, marker=None,
                        end_marker=None, prefix=None, delimiter=None,
                        headers=None):

--- a/tests/unit/test_objectstorage.py
+++ b/tests/unit/test_objectstorage.py
@@ -174,8 +174,6 @@ class ObjectStorageTest(unittest.TestCase):
         name = utils.random_string()
         api.container_delete(self.account, name, headers=self.headers)
 
-        api.directory.unlink.assert_called_once_with(
-            self.account, name, "meta2", headers=self.headers)
         uri = "%s/container/destroy" % self.uri_base
         params = {'acct': self.account, 'ref': name}
         api._request.assert_called_once_with(


### PR DESCRIPTION
(now handled by oio proxy)